### PR TITLE
Define lookahead parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ occurrence   = ("*" | "+" | "?")
 additional   = "|"? parser
 transform    = "->" '{' rust_code '}'
 atom         = alter? '(' parser ')' | CHAR | STRING | ident | '{' rust_code '}'
-alter        = ("^"|"!"|"#")
+alter        = ("^"|"!"|"#"|"/")
 ident        = [a..zA..Z]+ - {"let"}
 ```
 
@@ -35,6 +35,7 @@ The `alter` is a special annotation are:
 - `^` allowing the capability to recognize negation,
 - `!` allowing the capability to backtrack on failure and 
 - `#` allowing the capability to capture all chars.
+- `/` allowing the capability to lookahead without consuming scanned elements.
 
 The `#` alteration is important because it prevents massive list construction in memory. 
 

--- a/core/src/parser/lookahead.rs
+++ b/core/src/parser/lookahead.rs
@@ -1,0 +1,67 @@
+/*
+   Copyright 2019-2020 Didier Plaindoux
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+use std::marker::PhantomData;
+
+use crate::parser::parser::Combine;
+use crate::parser::parser::Parse;
+use crate::parser::response::Response;
+use crate::parser::response::Response::Reject;
+use crate::parser::response::Response::Success;
+use crate::stream::stream::Stream;
+
+#[derive(Copy, Clone)]
+pub struct Lookahead<P, A>(P, PhantomData<A>)
+    where
+        P: Combine<A>;
+
+impl<P, A> Combine<A> for Lookahead<P, A>
+    where
+        P: Combine<A>,
+{}
+
+impl<P, A, S> Parse<A, S> for Lookahead<P, A>
+    where
+        P: Parse<A, S> + Combine<A>,
+        S: Stream,
+{
+    fn parse(&self, s: S) -> Response<A, S> {
+        let Self(p, _) = self;
+
+        match p.parse(s.clone()) {
+            Success(a, _, ba) => Success(a, s, ba),
+            Reject(s, ba) => Reject(s, ba),
+        }
+    }
+
+    fn check(&self, s: S) -> Response<(), S> {
+        let Self(p, _) = self;
+
+        match p.parse(s.clone()) {
+            Success(a, _, ba) => Success((), s, ba),
+            Reject(s, ba) => Reject(s, ba),
+        }
+    }
+}
+
+pub fn lookahead<P, A, S>(p: P) -> impl Parse<A, S> + Combine<A>
+    where
+        A: Clone,
+        S: Stream,
+        P: Parse<A, S> + Combine<A>,
+{
+    Lookahead(p, PhantomData)
+}

--- a/core/src/parser/mod.rs
+++ b/core/src/parser/mod.rs
@@ -31,3 +31,4 @@ pub mod parser;
 pub mod repeat;
 pub mod response;
 pub mod satisfy;
+pub mod lookahead;

--- a/core/tests/parser/lookahead.rs
+++ b/core/tests/parser/lookahead.rs
@@ -1,0 +1,45 @@
+/*
+   Copyright 2019-2020 Didier Plaindoux
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#[cfg(test)]
+mod tests_and {
+    use celma_core::parser::and::AndOperation;
+    use celma_core::parser::char::char;
+    use celma_core::parser::lookahead::lookahead;
+    use celma_core::parser::parser::Parse;
+    use celma_core::stream::char_stream::CharStream;
+
+    #[test]
+    fn it_parse_one_character() {
+        let response = lookahead(char('a')).parse(CharStream::new("ab"));
+
+        assert_eq!(response.fold(|v, _, _| v == 'a', |_, _| false), true);
+    }
+
+    #[test]
+    fn it_parse_one_character_but_not_consume_it() {
+        let response = lookahead(char('a')).and_right(char('b')).parse(CharStream::new("ab"));
+
+        assert_eq!(response.fold(|_, _, _| false, |_, _| true), true);
+    }
+
+    #[test]
+    fn it_parse_one_character_and_consume_it_again() {
+        let response = lookahead(char('a')).and_right(char('a')).parse(CharStream::new("ab"));
+
+        assert_eq!(response.fold(|v, _, _| v == 'a', |_, _| false), true);
+    }
+}

--- a/core/tests/parser/mod.rs
+++ b/core/tests/parser/mod.rs
@@ -26,3 +26,4 @@ pub mod literal;
 pub mod option;
 pub mod or;
 pub mod repeat;
+pub mod lookahead;

--- a/lang/src/meta/first.rs
+++ b/lang/src/meta/first.rs
@@ -45,6 +45,7 @@ impl First<char> for ASTParsec {
             ASTParsec::POptional(p) => p.first(),     // TODO
             ASTParsec::PRepeat(true, p) => p.first(), // TODO
             ASTParsec::PRepeat(false, p) => p.first(),
+            ASTParsec::PLookahead(p) => p.first(),
         }
     }
 }

--- a/lang/src/meta/parser.rs
+++ b/lang/src/meta/parser.rs
@@ -28,10 +28,7 @@ use celma_core::parser::parser::{Combine, Parse};
 use celma_core::parser::repeat::RepeatOperation;
 use celma_core::stream::stream::Stream;
 
-use crate::meta::syntax::ASTParsec::{
-    PBind, PChar, PCheck, PChoice, PCode, PIdent, PMap, PNot, POptional, PRepeat, PSequence,
-    PString, PTry,
-};
+use crate::meta::syntax::ASTParsec::{PBind, PChar, PCheck, PChoice, PCode, PIdent, PMap, PNot, POptional, PRepeat, PSequence, PString, PTry, PLookahead};
 use crate::meta::syntax::{ASTParsec, ASTParsecRule};
 
 #[inline]
@@ -207,6 +204,10 @@ where
             .and_left(skip())
             .and_right(atom2())
             .fmap(|p| PCheck(Box::new(p))))
+        .or(char('/')
+            .and_left(skip())
+            .and_right(atom2())
+            .fmap(|p| PLookahead(Box::new(p))))
         .or(atom2())
 }
 

--- a/lang/src/meta/syntax.rs
+++ b/lang/src/meta/syntax.rs
@@ -29,6 +29,7 @@ pub enum ASTParsec {
     PCheck(Box<ASTParsec>),
     POptional(Box<ASTParsec>),
     PRepeat(bool, Box<ASTParsec>),
+    PLookahead(Box<ASTParsec>),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/lang/src/meta/transpiler.rs
+++ b/lang/src/meta/transpiler.rs
@@ -20,10 +20,7 @@ use proc_macro2::{Span, TokenStream};
 use quote::quote;
 
 use crate::meta::syntax::ASTParsec;
-use crate::meta::syntax::ASTParsec::{
-    PBind, PChar, PCheck, PChoice, PCode, PIdent, PMap, PNot, POptional, PRepeat, PSequence,
-    PString, PTry,
-};
+use crate::meta::syntax::ASTParsec::{PBind, PChar, PCheck, PChoice, PCode, PIdent, PMap, PNot, POptional, PRepeat, PSequence, PString, PTry, PLookahead};
 use crate::meta::syntax::ASTParsecRule;
 
 pub trait Transpile<E> {
@@ -63,6 +60,7 @@ impl Transpile<TokenStream> for ASTParsecRule {
                 use celma_core::parser::a_try::a_try;
                 use celma_core::parser::and::AndOperation;
                 use celma_core::parser::check::check;
+                use celma_core::parser::lookahead::lookahead;
                 use celma_core::parser::fmap::FMapOperation;
                 use celma_core::parser::not::NotOperation;
                 use celma_core::parser::option::OptionalOperation;
@@ -171,6 +169,10 @@ impl TranspileBody<(Option<String>, TokenStream)> for ASTParsec {
                 } else {
                     (None, quote!(#pt.rep()))
                 }
+            }
+            PLookahead(p) => {
+                let (_, pt) = p.transpile_body();
+                (None, quote!(lookahead(#pt)))
             }
         }
     }

--- a/lang/tests/parser/celma_parsec_rules_tests.rs
+++ b/lang/tests/parser/celma_parsec_rules_tests.rs
@@ -25,7 +25,7 @@ mod tests_and {
 
     #[test]
     fn it_parse_one_char_rule() {
-        let response = celma_parsec_rules().parse(CharStream::new("let a:{char} = {char('a')}"));
+        let response = celma_parsec_rules().parse(CharStream::new("let a:{char} = 'a'"));
 
         match response {
             Success(ast, _, _) => assert_eq!(
@@ -34,7 +34,7 @@ mod tests_and {
                     name: String::from("a"),
                     input: String::from("char"),
                     returns: String::from("char"),
-                    body: Box::new(PCode(String::from("char(\'a\')"))),
+                    body: Box::new(PChar('a')),
                 })
             ),
             _ => assert_eq!(true, false),

--- a/lang/tests/transpiler/celma_transpiler_rules_tests.rs
+++ b/lang/tests/transpiler/celma_transpiler_rules_tests.rs
@@ -45,6 +45,7 @@ mod tests_and {
                         use celma_core::parser::a_try::a_try;
                         use celma_core::parser::and::AndOperation;
                         use celma_core::parser::check::check;
+                        use celma_core::parser::lookahead::lookahead;
                         use celma_core::parser::fmap::FMapOperation;
                         use celma_core::parser::not::NotOperation;
                         use celma_core::parser::option::OptionalOperation;
@@ -64,6 +65,7 @@ mod tests_and {
                         use celma_core::parser::a_try::a_try;
                         use celma_core::parser::and::AndOperation;
                         use celma_core::parser::check::check;
+                        use celma_core::parser::lookahead::lookahead;
                         use celma_core::parser::fmap::FMapOperation;
                         use celma_core::parser::not::NotOperation;
                         use celma_core::parser::option::OptionalOperation;

--- a/lang/tests/transpiler/celma_transpiler_tests.rs
+++ b/lang/tests/transpiler/celma_transpiler_tests.rs
@@ -56,6 +56,40 @@ mod tests_and {
     }
 
     #[test]
+    fn it_transpile_two_characters_with_try_on_the_second_one() {
+        let response = celma_parsec()
+            .parse(CharStream::new("'a' !'b'"))
+            .fmap(|ast| ast.transpile_body());
+
+        match response {
+            Success((_, ast), _, _) => assert_eq!(
+                ast.to_string(),
+                quote!(celma_core::parser::char::char('a')
+                    .and_right(a_try(celma_core::parser::char::char('b'))))
+                    .to_string()
+            ),
+            _ => assert_eq!(true, false),
+        };
+    }
+
+    #[test]
+    fn it_transpile_two_characters_with_lookahead_on_the_second_one() {
+        let response = celma_parsec()
+            .parse(CharStream::new("'a' /'b'"))
+            .fmap(|ast| ast.transpile_body());
+
+        match response {
+            Success((_, ast), _, _) => assert_eq!(
+                ast.to_string(),
+                quote!(celma_core::parser::char::char('a')
+                    .and_right(lookahead(celma_core::parser::char::char('b'))))
+                    .to_string()
+            ),
+            _ => assert_eq!(true, false),
+        };
+    }
+
+    #[test]
     fn it_transpile_two_characters_bind_left() {
         let response = celma_parsec()
             .parse(CharStream::new("a='a' 'b'"))


### PR DESCRIPTION
- [X] Core library extended in order to support lookahead parsing style
- [x] Macro-based language extended

Closes #7 