### PR TITLE
Review lookahead

### DIFF
--- a/core/src/parser/lookahead.rs
+++ b/core/src/parser/lookahead.rs
@@ -1,0 +1,67 @@
+/*
+   Copyright 2019-2020 Didier Plaindoux
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+use std::marker::PhantomData;
+
+use crate::parser::parser::Combine;
+use crate::parser::parser::Parse;
+use crate::parser::response::Response;
+use crate::parser::response::Response::Reject;
+use crate::parser::response::Response::Success;
+use crate::stream::stream::Stream;
+
+#[derive(Copy, Clone)]
+pub struct Lookahead<P, A>(P, PhantomData<A>)
+    where
+        P: Combine<A>;
+
+impl<P, A> Combine<A> for Lookahead<P, A>
+    where
+        P: Combine<A>,
+{}
+
+impl<P, A, S> Parse<A, S> for Lookahead<P, A>
+    where
+        P: Parse<A, S> + Combine<A>,
+        S: Stream,
+{
+    fn parse(&self, s: S) -> Response<A, S> {
+        let Self(p, _) = self;
+
+        match p.parse(s.clone()) {
+            Success(a, _, ba) => Success(a, s, ba),
+            Reject(s, ba) => Reject(s, ba),
+        }
+    }
+
+    fn check(&self, s: S) -> Response<(), S> {
+        let Self(p, _) = self;
+
+        match p.check(s.clone()) {
+            Success(a, _, ba) => Success(a, s, ba),
+            Reject(s, ba) => Reject(s, ba),
+        }
+    }
+}
+
+pub fn lookahead<P, A, S>(p: P) -> impl Parse<A, S> + Combine<A>
+    where
+        A: Clone,
+        S: Stream,
+        P: Parse<A, S> + Combine<A>,
+{
+    Lookahead(p, PhantomData)
+}

--- a/core/src/parser/mod.rs
+++ b/core/src/parser/mod.rs
@@ -31,3 +31,4 @@ pub mod parser;
 pub mod repeat;
 pub mod response;
 pub mod satisfy;
+pub mod lookahead;

--- a/macro/tests/lang/basic.rs
+++ b/macro/tests/lang/basic.rs
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019-2020 Didier Plaindoux
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#[cfg(test)]
+mod tests_transpiler {
+    use celma_core::parser::and::AndOperation;
+    use celma_core::parser::core::eos;
+    use celma_core::parser::parser::Parse;
+    use celma_core::parser::response::Response::Success;
+    use celma_core::stream::char_stream::CharStream;
+    use celma_macro::parsec_rules;
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum Expr {
+        Text(String),
+        Var(String),
+        Seq(Vec<Expr>)
+    }
+
+    fn mk_string(a: Vec<char>) -> String {
+        a.into_iter().collect::<String>()
+    }
+
+    parsec_rules!(
+        let bash:{Expr} = s=(text | var)*       -> {Expr::Seq(s)}
+        let text:{Expr} = t=^('$' '{')+         -> {Expr::Text(mk_string(t))}
+        let var:{Expr}  = ('$' '{' v=^'}'* '}') -> {Expr::Var(mk_string(v))}
+    );
+
+    #[test]
+    fn it_parse_a_text() {
+        let response = bash().and_left(eos())
+            .parse(CharStream::new("Hello"));
+
+        match response {
+            Success(v, _, _) => assert_eq!(v, Expr::Seq(vec!(Expr::Text("Hello".to_owned())))),
+            _ => assert_eq!(true, false),
+        }
+    }
+
+    #[test]
+    fn it_parse_a_var() {
+        let response = bash().and_left(eos())
+            .parse(CharStream::new("${world}"));
+
+        match response {
+            Success(v, _, _) => assert_eq!(v, Expr::Seq(vec!(Expr::Var("world".to_owned())))),
+            _ => assert_eq!(true, false),
+        }
+    }
+
+    #[test]
+    fn it_parse_a_seq() {
+        let response = bash().and_left(eos())
+            .parse(CharStream::new("Hello ${world}"));
+
+        match response {
+            Success(v, _, _) => assert_eq!(v, Expr::Seq(vec!(Expr::Text("Hello ".to_owned()), Expr::Var("world".to_owned())))),
+            _ => assert_eq!(true, false),
+        }
+    }
+}

--- a/macro/tests/lang/mod.rs
+++ b/macro/tests/lang/mod.rs
@@ -15,6 +15,7 @@
 */
 
 pub mod expression;
+pub mod basic;
 pub mod pipeline;
 pub mod transpiler;
 pub mod transpiler_rules;


### PR DESCRIPTION
`Check` implementation reviewed and add a simple example for string interpolation

Closes #9 
See #10 