### PR TITLE
Fix generic type problem in negation construction

### DIFF
--- a/core/src/parser/not.rs
+++ b/core/src/parser/not.rs
@@ -28,11 +28,11 @@ pub struct Not<L, A>(L, PhantomData<A>)
 where
     L: Combine<A>;
 
-impl<L, A> Combine<A> for Not<L, A> where L: Combine<A> {}
+impl<L, A, B> Combine<A> for Not<L, B> where L: Combine<B> {}
 
-impl<L, A, S> Parse<A, S> for Not<L, A>
+impl<L, A, B, S> Parse<A, S> for Not<L, B>
 where
-    L: Parse<A, S> + Combine<A>,
+    L: Parse<B, S> + Combine<B>,
     S: Stream<Item = A>,
 {
     fn parse(&self, s: S) -> Response<A, S> {

--- a/core/tests/parser/mod.rs
+++ b/core/tests/parser/mod.rs
@@ -27,3 +27,4 @@ pub mod option;
 pub mod or;
 pub mod repeat;
 pub mod lookahead;
+pub mod not;

--- a/core/tests/parser/not.rs
+++ b/core/tests/parser/not.rs
@@ -16,38 +16,37 @@
 
 #[cfg(test)]
 mod tests_literal {
+    use celma_core::parser::char::char;
     use celma_core::parser::literal::string;
+    use celma_core::parser::not::NotOperation;
     use celma_core::parser::or::OrOperation;
     use celma_core::parser::parser::Parse;
+    use celma_core::parser::repeat::RepeatOperation;
+    use celma_core::parser::satisfy::not;
     use celma_core::stream::char_stream::CharStream;
+    use celma_core::parser::fmap::FMapOperation;
 
     #[test]
-    fn it_parse_a_str() {
-        let response = string("hello").parse(CharStream::new("hello world!"));
+    fn it_parse_any_char_else_char_b() {
+        let response = char('b').not().parse(CharStream::new("a"));
 
-        assert_eq!(response.fold(|v, _, _| v == "hello", |_, _| false), true);
+        assert_eq!(response.fold(|v, _, _| v == 'a', |_, _| false), true);
     }
 
     #[test]
-    fn it_parse_a_str_and_consume() {
-        let response = string("hello").parse(CharStream::new("hello world!"));
+    fn it_parse_any_char_else_string_b() {
+        let response = string("b").not().parse(CharStream::new("a"));
 
-        assert_eq!(response.fold(|_, _, b| b, |_, _| false), true);
+        assert_eq!(response.fold(|v, _, _| v == 'a', |_, _| false), true);
     }
 
     #[test]
-    fn it_cannot_parse_a_str() {
-        let response = string("Hello").parse(CharStream::new("hello world!"));
+    fn it_parse_any_chars_else_string_b() {
+        let response =
+            string("de").not().rep()
+                .fmap(|v| v.iter().collect::<String>())
+                .parse(CharStream::new("abcdcde"));
 
-        assert_eq!(response.fold(|_, _, _| false, |_, _| true), true);
-    }
-
-    #[test]
-    fn it_cannot_parse_a_str_with_a_or() {
-        let response = string("hek")
-            .or(string("hello"))
-            .parse(CharStream::new("hello world!"));
-
-        assert_eq!(response.fold(|v, _, _| v == "hello", |_, _| false), true);
+        assert_eq!(response.fold(|v, _, _| v == "abcdc".to_owned(), |_, _| false), true);
     }
 }

--- a/macro/tests/lang/basic.rs
+++ b/macro/tests/lang/basic.rs
@@ -35,9 +35,9 @@ mod tests_transpiler {
     }
 
     parsec_rules!(
-        let bash:{Expr} = s=(text | var)*       -> {Expr::Seq(s)}
-        let text:{Expr} = t=^('$' '{')+         -> {Expr::Text(mk_string(t))}
-        let var:{Expr}  = ('$' '{' v=^'}'* '}') -> {Expr::Var(mk_string(v))}
+        let bash:{Expr} = s=(text | var)*    -> {Expr::Seq(s)}
+        let text:{Expr} = t=^"${"+           -> {Expr::Text(mk_string(t))}
+        let var:{Expr}  = ("${" v=^'}'* '}') -> {Expr::Var(mk_string(v))}
     );
 
     #[test]


### PR DESCRIPTION
- [X] clean separation between the generic type of the embedded parser and the generic type of the stream element.

Closes #13 